### PR TITLE
Add -msiFile option to extract from MSI without installing IIS+CORS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,10 +2,9 @@
 
 ## Install
 
-1. [Install IIS](https://docs.microsoft.com/en-us/iis/install/installing-iis-7/installing-iis-on-windows-vista-and-windows-7).
-1. Install [Microsoft CORS Module for IIS](https://www.iis.net/downloads/microsoft/iis-cors-module).
 1. Install [IIS Express](https://docs.microsoft.com/en-us/iis/extensions/introduction-to-iis-express/iis-express-overview#installing-iis-express).
-1. Run `install.ps1` to install CORS module to IIS Express.
+1. Download [Microsoft CORS Module for IIS](https://www.iis.net/downloads/microsoft/iis-cors-module) installer.
+1. Run `install.ps1 -msiFile IISCORS_amd64.msi` to install CORS module to IIS Express.
 
 ## Uninstall
 1. Run `uninstall.ps1` to uninstall CORS module from IIS Express.

--- a/install.ps1
+++ b/install.ps1
@@ -8,17 +8,17 @@ param (
 $program32 = "${env:ProgramFiles(x86)}\IIS Express"
 $program64 = "${env:ProgramFiles}\IIS Express"
 
-$source32 = "${env:windir}\SysWOW64\inetsrv"
-$source64 = "${env:windir}\System32\inetsrv"
+$source32 = '\SysWOW64\inetsrv'
+$source64 = '\System32\inetsrv'
 
 $schema = '\config\schema\cors_schema.xml'
 $module = '\iiscors.dll'
 
-function AddSchemaFiles {
+function AddSchemaFiles([string]$sourceDir) {
 
     $schema32 = $program32 + $schema
     $schema64 = $program64 + $schema
-    $source = $source64 + $schema
+    $source = $sourceDir + $schema
     if (Test-Path $source) {
         Copy-Item $source -Destination $schema32
         Write-Host 'Added schema 32 bit.'
@@ -30,12 +30,12 @@ function AddSchemaFiles {
     }
 }
 
-function AddModuleFiles {
+function AddModuleFiles([string]$sourceDir) {
     $module32 = $program32 + $module
     $module64 = $program64 + $module
 
-    $sourceModule32 = $source32 + $module
-    $sourceModule64 = $source64 + $module
+    $sourceModule32 = $sourceDir + $source32 + $module
+    $sourceModule64 = $sourceDir + $source64 + $module
 
     if (Test-Path $sourceModule32) {
         Copy-Item $sourceModule32 -Destination $module32
@@ -115,8 +115,8 @@ if ($fileName) {
     PatchConfigFile($fileName)
 } else {
     Write-Host 'Configure all steps and default config file.'
-    AddSchemaFiles
-    AddModuleFiles
+    AddSchemaFiles(${env:windir} + $source64)
+    AddModuleFiles(${env:windir})
     PatchConfigFile([Environment]::GetFolderPath("MyDocuments") + "\IISExpress\config\applicationHost.config")
 }
 


### PR DESCRIPTION
Thanks for creating and maintaining these scripts!  It helped me figure out how to install the CORS module on IIS Express, which I've found very useful.

This pull request adds an `-msiFile` parameter to the script for specifying the location of the IIS CORS Module MSI file.  When `-msiFile` is specified, the required files are extracted from the MSI, which avoids the need to install IIS and the CORS module system-wide.

Thanks for considering,
Kevin